### PR TITLE
Match one or more Os in "ratio"

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,12 @@ client.on("ready", () => {
 
 client.on("messageCreate", async (message) => {
 	if (message.author.bot || !message.guild) return;
-	if (!message.content.toLowerCase().match("(?:^|\W)ratio(?:$|\W)|counter(?:$|\W)")) return;
+	if (
+		!message.content
+			.toLowerCase()
+			.match("(?:^|W)ratio+(?:$|W)|counter(?:$|W)")
+	)
+		return;
 
 	let ratio;
 


### PR DESCRIPTION
This PR allows 1 __or more__ `o`s in "ratio" to be matched, rather than just one.

`ratiooooooooooo` now available 😎